### PR TITLE
tests: adding test scenarios for error messages on the login page 

### DIFF
--- a/cypress/fixtures/login_selectors.js
+++ b/cypress/fixtures/login_selectors.js
@@ -2,4 +2,5 @@ export const loginSelectors = {
   usernameInput: '#user-name',
   passwordInput: '#password',
   loginButton: '#login-button',
+  errorMessage: '[data-test="error"]'
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,12 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+import { loginSelectors } from '../fixtures/login_selectors';
+
+Cypress.Commands.add('login',(username, password) => {
+    cy.visit('https://www.saucedemo.com/');
+    cy.get(loginSelectors.usernameInput).type(username);
+    cy.get(loginSelectors.passwordInput).type(password);
+    cy.get(loginSelectors.loginButton).click();
+  });


### PR DESCRIPTION
### Overview

This PR adds more login tests for the Saucedemo login page. The added tests are for the error messages that should appear on the login page.

### Changes

- Added tests to verify that error messages appear when invalid login data are supplied.
- Added selector for the error message element.
- Added custom command for logging in. 

### Why

Updating the login scenarios to more thoroughly test the login page.

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the login tests in the `login_spec.cy.js` file.