### PR TITLE
tests: adding test scenarios for the menu navigation

### DIFF
--- a/cypress/e2e/login_spec.cy.js
+++ b/cypress/e2e/login_spec.cy.js
@@ -37,13 +37,4 @@ describe('Login Functionality', () => {
     cy.get(inventorySelectors.productsList).should('be.visible') 
   })
 
-  //Click the left menu nav and then the Logout link to go back to the login page
-  it('should be logged out successfully to the login page after clicking Logout', () => {
-    cy.login('standard_user', 'secret_sauce')
-    cy.get(inventorySelectors.menuBar).click();
-    cy.get(inventorySelectors.logoutLink).should('be.visible').click();
-    cy.url().should('not.include', '/inventory.html');
-    cy.get(loginSelectors.loginButton).should('be.visible'); 
-  }) 
-
 })

--- a/cypress/e2e/menu_spec.cy.js
+++ b/cypress/e2e/menu_spec.cy.js
@@ -1,53 +1,62 @@
 import { menuSelectors } from '../fixtures/menu_selectors';
 import { inventorySelectors } from '../fixtures/inventory_selectors';
 import { shoppingCartSelectors } from '../fixtures/shopping_cart_selectors';
+import { loginSelectors } from '../fixtures/login_selectors';
 
 //Test left side menu for the site on multiple pages to confirm essential functionality is not broken
 //Also test the navigation links within the menu
 describe('Menu Functionality', () => {
 
-    beforeEach(() => {
-        cy.login('standard_user','secret_sauce');
-      }) 
+  beforeEach(() => {
+    cy.login('standard_user','secret_sauce');
+  }) 
 
-    it('should be able to open and close the menu on the inventory screen', () => {
-        cy.openMenu();
-        cy.closeMenu();
-    })
+  it('should be able to open and close the menu on the inventory screen', () => {
+    cy.openMenu();
+    cy.closeMenu();
+  })
 
-    it('should be able to open and close the menu on the shopping cart screen', () => {
-        cy.get(inventorySelectors.shoppingCartIcon).click();
-        cy.openMenu();
-        cy.closeMenu();
-    })
+  it('should be able to open and close the menu on the shopping cart screen', () => {
+    cy.get(inventorySelectors.shoppingCartIcon).click();
+    cy.openMenu();
+    cy.closeMenu();
+  })
 
-    it('should be able to open and close the menu on the checkout screen', () => {
-        cy.get(inventorySelectors.shoppingCartIcon).click();
-        cy.get(shoppingCartSelectors.checkoutButton).click();
-        cy.openMenu();
-        cy.closeMenu();
-    })
+  it('should be able to open and close the menu on the checkout screen', () => {
+    cy.get(inventorySelectors.shoppingCartIcon).click();
+    cy.get(shoppingCartSelectors.checkoutButton).click();
+    cy.openMenu();
+    cy.closeMenu();
+  })
 
-    it('should redirect to the inventory screen after clicking the All Items link', () => {
-        cy.openMenu();
-        cy.get(menuSelectors.allItemsLink).click();
-        cy.url().should('include', '/inventory.html'); 
-    })
+  it('should redirect to the inventory screen after clicking the All Items link', () => {
+    cy.get(inventorySelectors.shoppingCartIcon).click();
+    cy.openMenu();
+    cy.get(menuSelectors.allItemsLink).click();
+    cy.url().should('include', '/inventory.html'); 
+  })
 
-    it('should redirect to the Sauce Labs site after clicking the About link', () => {
+  it('should redirect to the Sauce Labs site after clicking the About link', () => {
         
-        //Catch any Javascript errors thrown by an external site and have Cypress ignore them as they are not relevant to this test
-        cy.on('uncaught:exception', (err) => {
-            return false;
-        });
+    //Catch any Javascript errors thrown by an external site and have Cypress ignore them as they are not relevant to this test
+    cy.on('uncaught:exception', (err) => {
+      return false;
+    });
 
-        cy.openMenu();
-        cy.get(menuSelectors.aboutLink).click();
+    cy.openMenu();
+    cy.get(menuSelectors.aboutLink).click();
         
-        //Allow Cypress commands to run in another domain, saucelabs.com, so we can confirm link functionality
-        cy.origin('https://saucelabs.com', () => {
-            cy.url().should('include', 'saucelabs.com'); //Confirm the About link goes to this external url
-        });
-    })
+    //Allow Cypress commands to run in another domain, saucelabs.com, so we can confirm link functionality
+    cy.origin('https://saucelabs.com', () => {
+      cy.url().should('include', 'saucelabs.com'); //Confirm the About link goes to this external url
+    });
+  })
+
+  it('should redirect to the login page and be logged out after clicking the Logout link', () => {
+    cy.openMenu();
+    cy.get(menuSelectors.logoutLink).click();
+    cy.url().should('not.include', '/inventory.html');
+    cy.get(loginSelectors.loginButton).should('be.visible'); 
+  }) 
 
 })

--- a/cypress/e2e/menu_spec.cy.js
+++ b/cypress/e2e/menu_spec.cy.js
@@ -1,0 +1,53 @@
+import { menuSelectors } from '../fixtures/menu_selectors';
+import { inventorySelectors } from '../fixtures/inventory_selectors';
+import { shoppingCartSelectors } from '../fixtures/shopping_cart_selectors';
+
+//Test left side menu for the site on multiple pages to confirm essential functionality is not broken
+//Also test the navigation links within the menu
+describe('Menu Functionality', () => {
+
+    beforeEach(() => {
+        cy.login('standard_user','secret_sauce');
+      }) 
+
+    it('should be able to open and close the menu on the inventory screen', () => {
+        cy.openMenu();
+        cy.closeMenu();
+    })
+
+    it('should be able to open and close the menu on the shopping cart screen', () => {
+        cy.get(inventorySelectors.shoppingCartIcon).click();
+        cy.openMenu();
+        cy.closeMenu();
+    })
+
+    it('should be able to open and close the menu on the checkout screen', () => {
+        cy.get(inventorySelectors.shoppingCartIcon).click();
+        cy.get(shoppingCartSelectors.checkoutButton).click();
+        cy.openMenu();
+        cy.closeMenu();
+    })
+
+    it('should redirect to the inventory screen after clicking the All Items link', () => {
+        cy.openMenu();
+        cy.get(menuSelectors.allItemsLink).click();
+        cy.url().should('include', '/inventory.html'); 
+    })
+
+    it('should redirect to the Sauce Labs site after clicking the About link', () => {
+        
+        //Catch any Javascript errors thrown by an external site and have Cypress ignore them as they are not relevant to this test
+        cy.on('uncaught:exception', (err) => {
+            return false;
+        });
+
+        cy.openMenu();
+        cy.get(menuSelectors.aboutLink).click();
+        
+        //Allow Cypress commands to run in another domain, saucelabs.com, so we can confirm link functionality
+        cy.origin('https://saucelabs.com', () => {
+            cy.url().should('include', 'saucelabs.com'); //Confirm the About link goes to this external url
+        });
+    })
+
+})

--- a/cypress/fixtures/inventory_selectors.js
+++ b/cypress/fixtures/inventory_selectors.js
@@ -1,6 +1,4 @@
 export const inventorySelectors = {
   productsList: '.inventory_list',
-  menuBar: '#react-burger-menu-btn',
-  logoutLink: '#logout_sidebar_link',
   shoppingCartIcon: '.shopping_cart_link'
 };

--- a/cypress/fixtures/inventory_selectors.js
+++ b/cypress/fixtures/inventory_selectors.js
@@ -2,4 +2,5 @@ export const inventorySelectors = {
   productsList: '.inventory_list',
   menuBar: '#react-burger-menu-btn',
   logoutLink: '#logout_sidebar_link',
+  shoppingCartIcon: '.shopping_cart_link'
 };

--- a/cypress/fixtures/menu_selectors.js
+++ b/cypress/fixtures/menu_selectors.js
@@ -1,0 +1,9 @@
+export const menuSelectors = {
+  open: '#react-burger-menu-btn',
+  menu: '.bm-menu-wrap',
+  allMenuLinks: '.bm-item-list',
+  allItemsLink: '#inventory_sidebar_link',
+  aboutLink: '#about_sidebar_link',
+  logoutLink: '#logout_sidebar_link',
+  close: '.bm-cross-button'
+};

--- a/cypress/fixtures/shopping_cart_selectors.js
+++ b/cypress/fixtures/shopping_cart_selectors.js
@@ -1,0 +1,3 @@
+export const shoppingCartSelectors = {
+  checkoutButton: '#checkout'
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,10 +25,24 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 import { loginSelectors } from '../fixtures/login_selectors';
+import { menuSelectors } from '../fixtures/menu_selectors';
 
+//Login Commands
 Cypress.Commands.add('login',(username, password) => {
     cy.visit('https://www.saucedemo.com/');
     cy.get(loginSelectors.usernameInput).type(username);
     cy.get(loginSelectors.passwordInput).type(password);
     cy.get(loginSelectors.loginButton).click();
   });
+
+// Menu Commands
+Cypress.Commands.add('openMenu', () => {
+  cy.get(menuSelectors.open).should('be.visible').click();
+  cy.get(menuSelectors.menu).should('have.attr', 'aria-hidden', 'false');
+  cy.get(menuSelectors.allMenuLinks).should('be.visible');
+});
+
+Cypress.Commands.add('closeMenu', () => {
+  cy.get(menuSelectors.close).click();
+  cy.get(menuSelectors.menu).should('have.attr', 'aria-hidden', 'true');
+});


### PR DESCRIPTION
### Overview

This PR adds tests for the site navigation on the Sauce Demo site. 

### Changes

- Added tests to verify the menu can open and close on critical pages.
- Added custom commands for opening and closing the menu since this is tested on multiple pages.
- Added tests to confirm the menu navigation links work as expected.
- Added selectors for the menu and other pages necessary for tests.

### Why

This confirms site navigation is functional and works on multiple pages of the site. These are crucial tests to ensure proper user experience.

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the login tests in the `menu_spec.cy.js` file.