### PR TITLE
chore: set up config for github actions

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -1,0 +1,29 @@
+name: Run Cypress Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:  # Runs on all PRs, no matter the branch
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [chrome, firefox] # Cross browser testing
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20 # This version will be supported for a while
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Cypress Tests in ${{ matrix.browser }}
+        run: npx cypress run --browser ${{ matrix.browser }} --headless

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        browser: [chrome, firefox] # Cross browser testing
+        browser: [chrome, firefox] # Enable cross browser testing for Github Actions
     
     steps:
       - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cypress run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Overview

This PR sets up Github Actions. Any time a PR gets created with main branch as the base, it should run all the Cypress tests.

### Changes

- Created a YAML file to house the Github Actions configuration.
- Updated `package.json` to help Guthub Actions run Cypress tests automatically.

### Why

This should prevent PRs being able to merge to main unless all Cypress scripts pass first. This keeps the main branch stable.