### PR TITLE
test: add test scenarios to confirm site functions on mobile

### DIFF
--- a/cypress/e2e/mobile_spec.cy.js
+++ b/cypress/e2e/mobile_spec.cy.js
@@ -1,0 +1,46 @@
+import { loginSelectors } from '../fixtures/login_selectors';
+import { inventorySelectors } from '../fixtures/inventory_selectors';
+import { shoppingCartSelectors } from '../fixtures/shopping_cart_selectors';
+
+describe('Mobile Testing - Using Galaxy S main series screensize', () => {
+
+    beforeEach(() => {
+      // Set viewport screen to mimic S series screensize since S22 to test all scenarios
+      cy.viewport(360, 780); 
+    }) 
+  
+    it('Should display login form correctly on mobile', () => {
+      cy.visit("https://www.saucedemo.com/");
+      cy.get(loginSelectors.usernameInput).should("be.visible");
+      cy.get(loginSelectors.passwordInput).should("be.visible");
+      cy.get(loginSelectors.loginButton).should("be.visible");
+    })
+
+    it('Should display the full product list on mobile after logging in', () => {
+      cy.login('standard_user','secret_sauce');
+      
+      // Confirm all 6 products appear on the page from top to bottom
+      cy.get(inventorySelectors.productsList)
+        .children("div")
+        .should("have.length", 6) 
+        .last()
+        .scrollIntoView()
+        .should("be.visible");
+    })
+
+    it('Should be able to open and close the navigation menu on mobile', () => {
+      cy.login('standard_user','secret_sauce');
+      cy.openMenu();
+      cy.closeMenu();
+    })
+
+    it('Should be able to add product to cart on mobile', () => {
+      cy.login('standard_user','secret_sauce');
+      cy.get(inventorySelectors.shoppingCartIcon).invoke('text').should('be.empty'); 
+      cy.get(inventorySelectors.addBackpackToCart).click();
+      cy.get(inventorySelectors.shoppingCartIcon).invoke('text').should('not.be.empty'); 
+      cy.get(inventorySelectors.shoppingCartIcon).click();
+      cy.get(shoppingCartSelectors.productName).should('have.text','Sauce Labs Backpack');
+    })
+
+})


### PR DESCRIPTION
### Overview

This PR adds tests for site functionality on mobile phones, specifically for Galaxy S phones which are some of the popular android models. More viewports can be added upon request based on use cases.

### Changes

- Added tests to verify login and inventory pages also work on mobile.
- Added test to verify the navigation menu bar can open/close on mobile as well. 

### Why

It's important to not only cross browser test, but to confirm that websites work on mobile phones as well. Many people shop using mobile phones and it's important to make sure functionality that works on desktop also works on mobile.

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the login tests in the `mobile_spec.cy.js` file.