### PR TITLE
test: update config to handle API tests and add authentication tests 

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:  # Runs on all PRs, no matter the branch
 
 jobs:
-  cypress-run:
+  cypress-ui:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,5 +25,22 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run Cypress Tests in ${{ matrix.browser }}
+      - name: Run UI Tests in ${{ matrix.browser }}
         run: npx cypress run --browser ${{ matrix.browser }} --headless
+
+  cypress-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run API Tests
+        run: npx cypress run --headless --spec "cypress/e2e/api/*.cy.js"

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,8 +2,6 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
-    setupNodeEvents(on, config) {
-      // implement node event listeners here
-    },
+    baseUrl: "https://restful-booker.herokuapp.com",
   },
 });

--- a/cypress/e2e/api/auth.cy.js
+++ b/cypress/e2e/api/auth.cy.js
@@ -1,0 +1,63 @@
+describe("Successful Authentication", () => {
+  it("Should generate a token with valid login", () => {
+    cy.request({
+      method: "POST",
+      url: "/auth",
+      body: {
+        username: "admin",
+        password: "password123",
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(200);
+      
+      // Assert token length so token itself is not exposed
+      expect(response.body.token.length).to.be.equal(15);
+
+      // Save auth token for later tests
+      cy.wrap(response.body.token, { log: false }).as("authToken");
+    });
+  });
+})
+
+describe("Failed Authentication", () => {
+  it("Should return an error message if login is invalid", () => {
+    cy.request({
+      method: "POST",
+      url: "/auth",
+      body: {
+        username: "admin",
+        password: "pass",
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(200); 
+      expect(response.body).to.deep.equal({ reason: "Bad credentials" });
+    });
+  });  
+
+  it("Should return an error message if one of the login fields is missing", () => {
+    cy.request({
+      method: "POST",
+      url: "/auth",
+      body: {
+        username: "admin",
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(200); 
+      expect(response.body).to.deep.equal({ reason: "Bad credentials" });
+    });
+  });
+  
+  it("Should return an error message if both user and pass are blank", () => {
+    cy.request({
+      method: "POST",
+      url: "/auth",
+      body: {
+        username: "",
+        password: "",
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(200); 
+      expect(response.body).to.deep.equal({ reason: "Bad credentials" });
+    });
+  });  
+});


### PR DESCRIPTION
### Overview

This PR begins testing of the API for the Restful-Booker site. It starts with tests of the API authentication functionality.

### Changes

- Update YAML file so that UI and API tests can run separately with Github Actions.
- Add tests for API authentication for both valid and invalid logins.

### Why
API tests are necessary for testing that 3rd party integrations function with your API. It is also an alternative to some types of UI testing without the lag UI loading can add.

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the login tests in the `api/auth_spec.cy.js` file.