### PR TITLE
Test/UI test errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 cypress.env.json
 cypress/reports/
+cypress/screenshots/

--- a/cypress/e2e/ui/error-spec.cy.js
+++ b/cypress/e2e/ui/error-spec.cy.js
@@ -8,7 +8,7 @@ describe('UI Errors', () => {
     cy.login('error_user','secret_sauce');
   }) 
 
-  it('KNOWN BUG: Remove button does not work on the Inventory page', () => {
+  it('KNOWN BUG: Remove button does not work on the inventory page', () => {
     cy.get(inventorySelectors.addBackpackToCart).click();
     
     // This is to catch the error that will occur in the cy.get following this so the test passes
@@ -34,7 +34,7 @@ describe('UI Errors', () => {
     })
   })
     
-  it('KNOWN BUG: Last Name field on the checkout page is not accepting text input', () => {
+  it('KNOWN BUG: Last Name field on the checkout page is not accepting input', () => {
     cy.get(inventorySelectors.addBackpackToCart).click();
     cy.get(inventorySelectors.shoppingCartIcon).click();
     cy.get(shoppingCartSelectors.checkoutButton).click();

--- a/cypress/e2e/ui/error-spec.cy.js
+++ b/cypress/e2e/ui/error-spec.cy.js
@@ -42,7 +42,7 @@ describe('UI Errors', () => {
     cy.get(checkoutSelectors.zipCode).type('10000'); 
     
     cy.on('uncaught:exception', (err, runnable) => {
-      expect(err.message).to.include('Cannot read properties of undefined');
+      expect(err.message).to.include('undefined');
       return false;
     });
     cy.get(checkoutSelectors.lastName).type('Last');  

--- a/cypress/e2e/ui/error-spec.cy.js
+++ b/cypress/e2e/ui/error-spec.cy.js
@@ -1,0 +1,66 @@
+import { checkoutSelectors } from '../../fixtures/checkout-selectors';
+import { inventorySelectors } from '../../fixtures/inventory-selectors';
+import { shoppingCartSelectors } from '../../fixtures/shopping-cart-selectors';
+
+describe('UI Errors', () => {
+  
+  beforeEach(() => {
+    cy.login('error_user','secret_sauce');
+  }) 
+
+  it('KNOWN BUG: Remove button does not work on the Inventory page', () => {
+    cy.get(inventorySelectors.addBackpackToCart).click();
+    
+    // This is to catch the error that will occur in the cy.get following this so the test passes
+    cy.on('uncaught:exception', (err, runnable) => {
+      expect(err.message).to.include('Failed to remove item from cart');
+      return false;
+    });
+    cy.get(inventorySelectors.removeBackpackFromCart).should('be.visible').click();
+  })
+
+  // The bug in this case calls an alert box, so I use a stub method to catch it and assert it neatly in the loop
+  it('KNOWN BUG: Only the first sorting option works on the inventory page', () => {
+    const dropdownOptions = ['Name (Z to A)', 'Price (low to high)', 'Price (high to low)'];
+    const alertStub = cy.stub();
+    cy.on('window:alert', alertStub);
+    
+    // Select each sorting option and see if the error alert box comes up for each one
+    dropdownOptions.forEach((option) => {
+      cy.get(inventorySelectors.sortProducts).select(option).then(() => {
+        expect(alertStub).to.have.been.calledWith('Sorting is broken! This error has been reported to Backtrace.');
+        alertStub.resetHistory(); // Without this, the assert above will pass if the alert shows just once
+      })
+    })
+  })
+    
+  it('KNOWN BUG: Last Name field on the checkout page is not accepting text input', () => {
+    cy.get(inventorySelectors.addBackpackToCart).click();
+    cy.get(inventorySelectors.shoppingCartIcon).click();
+    cy.get(shoppingCartSelectors.checkoutButton).click();
+    cy.get(checkoutSelectors.firstName).type('First');
+    cy.get(checkoutSelectors.zipCode).type('10000'); 
+    
+    cy.on('uncaught:exception', (err, runnable) => {
+      expect(err.message).to.include('Cannot read properties of undefined');
+      return false;
+    });
+    cy.get(checkoutSelectors.lastName).type('Last');  
+    })
+
+  it('KNOWN BUG: Finish button is not clickable on final checkout page', () => {
+    cy.get(inventorySelectors.addBackpackToCart).click();
+    cy.get(inventorySelectors.shoppingCartIcon).click();
+    cy.get(shoppingCartSelectors.checkoutButton).click();
+    cy.get(checkoutSelectors.firstName).type('First');
+    cy.get(checkoutSelectors.zipCode).type('10000'); 
+    cy.get(checkoutSelectors.continueButton).click();
+    
+    cy.on('uncaught:exception', (err, runnable) => {
+      expect(err.message).to.include('C.cesetRart is not a function');
+      return false;
+    });
+    cy.get(checkoutSelectors.finishButton).click()  
+    })
+
+  })

--- a/cypress/fixtures/checkout-selectors.js
+++ b/cypress/fixtures/checkout-selectors.js
@@ -1,0 +1,7 @@
+export const checkoutSelectors = {
+  firstName: '#first-name',
+  lastName: '#last-name',
+  zipCode: '#postal-code',
+  continueButton: '#continue',
+  finishButton: '#finish'
+}

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,4 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
+
+// Allows screenshots to be embedded within reports that have failed tests
+import 'cypress-mochawesome-reporter/register';


### PR DESCRIPTION
### Overview

This PR introduces a suite of tests that document known UI errors on the Sauce Demo site using the `error_user` login. These tests are intentionally designed to expose known bugs and provide clear documentation for future reference. Relevant bug reports are linked where applicable.

### Changes

- Added test to demonstrate that the Remove button on the inventory page does not work.
- Added test to show that sorting options on the inventory page generate errors.
- Added test to demonstrate that the Last Name field on the checkout page does not accept input.
- Added test to show that the Finish button on the checkout page does not work, preventing orders from being completed.
- Added selectors for the checkout pages.
- Added configuration to allow screenshots to be embedded in reports when tests fail.

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the UI test by selecting the `error-spec.cy.js` file.