### PR TITLE
test: add tests to catch API errors

### DIFF
--- a/cypress/data/booking-data.js
+++ b/cypress/data/booking-data.js
@@ -1,0 +1,11 @@
+export const baseBooking = {
+  firstname: "John",
+  lastname: "Doe",
+  totalprice: 150,
+  depositpaid: true,
+  bookingdates: {
+    checkin: "2024-06-01",
+    checkout: "2024-06-10"
+  },
+  additionalneeds: "Breakfast"
+} 

--- a/cypress/e2e/api/error-spec.cy.js
+++ b/cypress/e2e/api/error-spec.cy.js
@@ -1,0 +1,75 @@
+import { baseBooking } from '../../data/booking-data';
+
+describe('API error tests', () => { 
+  it ('KNOWN BUG: API errors when First Name field is not a string', () => {
+    cy.request({
+      method: 'POST',
+      url: '/booking',
+      
+      // Status code setting is needed in order for tests to pass when fail statuses are expected
+      failOnStatusCode: false,
+      
+      // Use ... operator to make copy of the API body and then change the needed field for test
+      body: {
+        ...baseBooking,
+        firstname: 123
+    }
+    }).then((response) => {
+      expect(response.status).to.eq(500);
+      expect(response.body).to.equal('Internal Server Error');
+    });
+  });
+
+  it ('KNOWN BUG: API errors when Last Name field is not a string', () => {
+    cy.request({
+      method: 'POST',
+      url: '/booking',
+      failOnStatusCode: false,
+      body: {
+        ...baseBooking,
+        lastname: 456
+    }
+    }).then((response) => {
+      expect(response.status).to.eq(500);
+      expect(response.body).to.equal('Internal Server Error');
+    });
+  });
+})
+
+// Test both string and numerical values to show field is not erroring out correctly
+describe('API invalid value tests', () => { 
+  const invalidDepositValues = ['x', 4];
+  
+  //Test both values using a loop through the small array above
+  invalidDepositValues.forEach((invalidValue) => { 
+    it (`KNOWN BUG: Depositpaid field converts invalid value (${invalidValue}) to true`, () => {
+      cy.request({
+        method: 'POST',
+        url: '/booking',
+        body: {
+          ...baseBooking,
+          depositpaid: invalidValue
+      }
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.have.property('bookingid');
+        expect(response.body.booking.depositpaid).to.equal(true);
+      });
+    });
+  });
+
+  it('KNOWN BUG: Totalprice converts a string value to null instead of sending error', () => {
+    cy.request({
+      method: 'POST',
+      url: '/booking',
+      body: {
+        ...baseBooking,
+        totalprice: 'x'
+    }
+    }).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('bookingid');
+      expect(response.body.booking.totalprice).to.equal(null);
+    });
+  });   
+})


### PR DESCRIPTION
### Overview

This PR introduces a suite of tests that document known API errors on the Restful Booker site. These tests are intentionally designed to expose known bugs and provide clear documentation for future reference. Relevant bug reports are linked where applicable.

### Changes

- Added test to demonstrate that the `firstname` and `lastname` fields cause server failure when given non-string values.
- Added test to show that the `depositpaid` field accepts non-boolean values on a boolean field.
- Added test to demonstrate that the `totalprice` field accepts non-numerical values.
- Moved base API record for tests to an external file.

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the API test by selecting the `api/error-spec.cy.js` file.