### PR TITLE
test: add test to confirm PUT fails without required fields

### DIFF
--- a/cypress/e2e/api/auth.cy.js
+++ b/cypress/e2e/api/auth.cy.js
@@ -3,7 +3,10 @@ describe('Successful Authentication', () => {
     cy.request({
       method: 'POST',
       url: '/auth',
-      body: { username: Cypress.env('BOOKING_USERNAME'), password: Cypress.env('BOOKING_PASSWORD')},
+      body: { 
+        username: Cypress.env('BOOKING_USERNAME'), 
+        password: Cypress.env('BOOKING_PASSWORD')
+      },
     }).then((response) => {
       expect(response.status).to.eq(200);
       
@@ -21,7 +24,10 @@ describe('Failed Authentication', () => {
     cy.request({
       method: 'POST',
       url: '/auth',
-      body: { username: 'admin', password: 'pass' },
+      body: { 
+        username: 'admin', 
+        password: 'pass' 
+      },
     }).then((response) => {
       expect(response.status).to.eq(200); 
       expect(response.body).to.deep.equal({ reason: 'Bad credentials' });
@@ -43,7 +49,10 @@ describe('Failed Authentication', () => {
     cy.request({
       method: 'POST',
       url: '/auth',
-      body: { username: '', password: '' },
+      body: { 
+        username: '', 
+        password: '' 
+      },
     }).then((response) => {
       expect(response.status).to.eq(200); 
       expect(response.body).to.deep.equal({ reason: 'Bad credentials' });

--- a/cypress/e2e/api/error-spec.cy.js
+++ b/cypress/e2e/api/error-spec.cy.js
@@ -13,7 +13,7 @@ describe('API error tests', () => {
       body: {
         ...baseBooking,
         firstname: 123
-    }
+      }
     }).then((response) => {
       expect(response.status).to.eq(500);
       expect(response.body).to.equal('Internal Server Error');
@@ -28,7 +28,7 @@ describe('API error tests', () => {
       body: {
         ...baseBooking,
         lastname: 456
-    }
+      }
     }).then((response) => {
       expect(response.status).to.eq(500);
       expect(response.body).to.equal('Internal Server Error');
@@ -49,7 +49,7 @@ describe('API invalid value tests', () => {
         body: {
           ...baseBooking,
           depositpaid: invalidValue
-      }
+        }
       }).then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body).to.have.property('bookingid');

--- a/cypress/e2e/api/update-booking-spec.cy.js
+++ b/cypress/e2e/api/update-booking-spec.cy.js
@@ -9,7 +9,10 @@ describe('Update booking API Test', () => {
     cy.request({
       method: 'POST',
       url: '/auth',
-      body: { username: Cypress.env('BOOKING_USERNAME'), password: Cypress.env('BOOKING_PASSWORD')}
+      body: { 
+        username: Cypress.env('BOOKING_USERNAME'), 
+        password: Cypress.env('BOOKING_PASSWORD')
+      }
     }).then((response) => {
       expect(response.status).to.eq(200);
       
@@ -27,13 +30,31 @@ describe('Update booking API Test', () => {
       bookingId = response.body.bookingid;
     });
   });
+
+  it('Should return 400 Bad Request if not all required fields are included in PUT request', () => {
+    cy.request({
+      method: 'PUT',
+      url: `/booking/${bookingId}`,
+      failOnStatusCode: false,
+      
+      // Include authentication token from above which is required for booking updates
+      headers: { 'Cookie': `token=${authToken}` },
+      
+      // This is missing other necessary fields like totalprice, bookingdates etc
+      body: {
+        firstname: "Jane", 
+        lastname: "Rivera"
+      }
+    }).then((response) => {
+      expect(response.status).to.eq(400);
+      expect(response.body).to.equal('Bad Request');
+    })
+  })
   
   it('Should update all booking fields properly', () => {
     cy.request({
       method: 'PUT',
       url: `/booking/${bookingId}`,
-      
-      // Include authentication token from above which is required for booking updates
       headers: { 'Cookie': `token=${authToken}` },
       body: updatedBooking
     }).then((response) => {


### PR DESCRIPTION
### Overview

This PR adds a test case to show PUT request fails when given a record that doesn't have all required fields for the Restful Booker API.

### Changes

- Added test to show API returns 400 with incomplete record for PUT request.
- Made some minor formatting changes to API files.

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the API test by selecting the `update-booking-spec.cy.js` file.