### PR TITLE
test: add happy path test for Sauce Demo

### DIFF
--- a/cypress/e2e/ui/happy-path-spec.cy.js
+++ b/cypress/e2e/ui/happy-path-spec.cy.js
@@ -1,0 +1,27 @@
+import { inventorySelectors } from '@/selectors/inventory-selectors';
+import { shoppingCartSelectors } from '@/selectors/shopping-cart-selectors';
+import { checkoutSelectors } from '@/selectors/checkout-selectors';
+
+describe('Full checkout test', () => {
+
+  beforeEach(() => {
+    cy.login('standard_user','secret_sauce');
+  }) 
+
+  it('Should complete a full checkout flow from cart to confirmation', () => {
+    cy.get(inventorySelectors.addBackpackToCart).click();
+    cy.get(inventorySelectors.shoppingCartIcon).click();
+    cy.get(shoppingCartSelectors.productName).should('have.text','Sauce Labs Backpack'); // Confirm it's the correct item
+    cy.get(shoppingCartSelectors.checkoutButton).click();
+    cy.get(checkoutSelectors.firstName).type('First');
+    cy.get(checkoutSelectors.lastName).type('Last');
+    cy.get(checkoutSelectors.zipCode).type('10000'); 
+    cy.get(checkoutSelectors.continueButton).click();
+    cy.get(checkoutSelectors.finishButton).click();
+    
+    cy.get(checkoutSelectors.checkoutComplete).should('have.text','Checkout: Complete!');  
+    cy.get(checkoutSelectors.thankYouText).should('have.text','Thank you for your order!');
+    cy.get(checkoutSelectors.homeButton).should('be.visible').click();
+    cy.url().should('include', '/inventory.html');   
+  })
+})

--- a/cypress/selectors/checkout-selectors.js
+++ b/cypress/selectors/checkout-selectors.js
@@ -3,5 +3,8 @@ export const checkoutSelectors = {
   lastName: '#last-name',
   zipCode: '#postal-code',
   continueButton: '#continue',
-  finishButton: '#finish'
+  finishButton: '#finish',
+  thankYouText: '.complete-header',
+  checkoutComplete: '.title',
+  homeButton: '#back-to-products'
 }


### PR DESCRIPTION
### Overview

This PR adds a test for the complete checkout flow — from adding an item to the cart through order confirmation. It verifies that the full checkout functionality works as expected, including product validation and final thank you message.

### Changes

- Added a full end-to-end happy path test for the checkout process
- Added additional checkout selectors to support this test

### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Open Cypress: `npx cypress open`
5. Run the UI test by selecting the `happy-path-spec.cy.js` file.