### PR TITLE
chore: add spec runs to cypress cloud during pull requests

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -29,7 +29,9 @@ jobs:
         run: rm -rf cypress/reports || true # Delete reports folder (removes old screenshots, logs etc)
 
       - name: Run UI Tests in ${{ matrix.browser }}
-        run: npx cypress run --browser ${{ matrix.browser }} --headless --spec "cypress/e2e/ui/*.cy.js"
+        env: 
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} # Get record key from Github secrets for Cypress Cloud runs
+        run: npx cypress run --browser ${{ matrix.browser }} --headless --spec "cypress/e2e/ui/*.cy.js" --record
 
       - name: Upload UI report
         uses: actions/upload-artifact@v4
@@ -55,11 +57,12 @@ jobs:
       - name: Clean Reports Folder
         run: rm -rf cypress/reports || true
 
-      - name: Run API Tests # Get API auth login from Github secrets
+      - name: Run API Tests 
         env:
-          CYPRESS_BOOKING_USERNAME: ${{ secrets.CYPRESS_BOOKING_USERNAME }}
+          CYPRESS_BOOKING_USERNAME: ${{ secrets.CYPRESS_BOOKING_USERNAME }} # Get API auth login from Github secrets
           CYPRESS_BOOKING_PASSWORD: ${{ secrets.CYPRESS_BOOKING_PASSWORD }}
-        run: npx cypress run --headless --spec "cypress/e2e/api/*.cy.js"
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} 
+        run: npx cypress run --headless --spec "cypress/e2e/api/*.cy.js" --record
 
       - name: Upload API report
         uses: actions/upload-artifact@v4

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,6 +3,7 @@ const webpack = require('@cypress/webpack-preprocessor');
 const webpackConfig = require('./webpack.config.js');
 
 module.exports = defineConfig({
+  projectId: 'in78pu', // Project ID is used for Cypress Cloud
   e2e: {
     baseUrl: 'https://restful-booker.herokuapp.com',
     setupNodeEvents(on, config) {


### PR DESCRIPTION
### Overview

This PR integrates Cypress Cloud into the test workflow, enabling all UI and API test runs to be automatically recorded and viewable through the Cypress Cloud dashboard.

This provides better visibility, historical tracking, and easier debugging of failures directly from the web interface.

### Changes

- Added `CYPRESS_RECORD_KEY` to the GitHub Actions workflow for both UI and API tests
- Included the `--record` flag in test commands to enable cloud uploads
- Added `projectId` to `cypress.config.js` to link the repo to the correct Cypress Cloud project
 
### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Run all Cypress tests and send results to Cypress Cloud: `npx cypress run --record`

**Note:** Make sure you have the `CYPRESS_RECORD_KEY` available in your `cypress.env.json` file if running locally.