### PR TITLE
chore: add descriptive labels for cypress cloud dashboard

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run UI Tests in ${{ matrix.browser }}
         env: 
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} # Get record key from Github secrets for Cypress Cloud runs
-        run: npx cypress run --browser ${{ matrix.browser }} --headless --spec "cypress/e2e/ui/*.cy.js" --record
+        run: npx cypress run --browser ${{ matrix.browser }} --headless --spec "cypress/e2e/ui/*.cy.js" --record --group "UI Tests - ${{ matrix.browser }}"
 
       - name: Upload UI report
         uses: actions/upload-artifact@v4
@@ -62,7 +62,7 @@ jobs:
           CYPRESS_BOOKING_USERNAME: ${{ secrets.CYPRESS_BOOKING_USERNAME }} # Get API auth login from Github secrets
           CYPRESS_BOOKING_PASSWORD: ${{ secrets.CYPRESS_BOOKING_PASSWORD }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} 
-        run: npx cypress run --headless --spec "cypress/e2e/api/*.cy.js" --record
+        run: npx cypress run --headless --spec "cypress/e2e/api/*.cy.js" --record --group "API Tests"
 
       - name: Upload API report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Overview

This PR improves Cypress Cloud test run visibility by adding descriptive labels to each test group.
These labels make it easier to identify which tests were run in each environment (UI vs API, browser type).

### Changes

- Added --group flags to the GitHub Actions workflow to label test runs as:
  - UI Tests - Chrome
  - UI Tests - Firefox
  - API Tests
 
### How to Test

1. Clone the repository: `git clone <repo-url>`
2. Navigate to the repo folder: `cd <repo-folder>`
3. Install dependencies in that folder: `npm install`
4. Run all Cypress tests and send results to Cypress Cloud: `npx cypress run --record`

**Note:** Make sure you have the `CYPRESS_RECORD_KEY` available in your `cypress.env.json` file if running locally.