### PR TITLE
 docs(readme): updating text - superseded by #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ project-root/
 7. To use the Cypress test runner UI to run tests: `npx cypress open`
 
 ## Mobile Testing
-This project includes a Cypress spec that validates SauceDemo’s UI responsiveness in a mobile viewport (Samsung Galaxy S22, 360×780). This ensures the application layout and functionality remain consistent on smaller screens. The test file is at `cypress/e2e/mobile-spec.cy.js`.
+This project includes a Cypress spec that validates SauceDemo’s UI responsiveness in a mobile viewport (Samsung Galaxy S22, 360×780). This ensures the application layout and functionality remain consistent on smaller screens. The test file is at `cypress/e2e/ui/mobile-spec.cy.js`.
 
 ![Mobile viewport test of SauceDemo site](./images/mobile-saucedemo.png)
 
 ## Bug Tracking
 Automated tests for known bugs are located in:
-- `ui-error-spec.cy.js`
-- `api-error-spec.cy.js`
-- `auth.cy.js` (for authentication-related errors)<br>
+- `cypress/e2e/ui/ui-error-spec.cy.js`
+- `cypress/e2e/api/api-error-spec.cy.js`
+- `cypress/e2e/api/auth-spec.cy.js`
 
 Since the JIRA board isn’t publicly accessible, I’ve included screenshots of the bug tickets I created. Each file is named with its Jira ticket number and a short description, and those ticket IDs match the ones referenced in the test cases above. View the folder [here](https://github.com/AlexMolCode/cypress-automation-tests/tree/main/bug-reports).
 


### PR DESCRIPTION
Note: Superseded by https://github.com/AlexMolCode/cypress-automation-tests/pull/47 (final README update). Kept for historical context.

### Overview

Corrected file paths in the README to ensure all references point to the right locations.

### Changes

- Updated all file paths to their correct locations.