### PR TITLE
 docs(readme): updating folder text - superseded by #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cypress-automation-tests/
 │   ├── reports/         # Mochawesome test reports (local only)
 │   ├── selectors/       # Page object Model selectors for UI tests
 │   ├── support/         # Reusable UI commands (login, navigation)
-├── bug-reports          # Screenshots of Jira bug tickets
+├── bug-reports/         # Screenshots of Jira bug tickets
 ```
 ## Running Tests Locally
 1. Make sure you have Git installed: [Download Git](https://git-scm.com/downloads)


### PR DESCRIPTION
Note: Superseded by https://github.com/AlexMolCode/cypress-automation-tests/pull/47 (final README update). Kept for historical context.

### Overview

Corrected the folder structure formatting in the README by adding missing trailing / to folder name.

### Changes

- Added missing / at the end of the folder name in the structure tree for consistency.