### PR TITLE
(not used) chore: update yml file to upload report to GitHub Pages

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -44,11 +44,15 @@ jobs:
               --reporter mochawesome \
               --reporter-options "reportDir=cypress/reports,overwrite=false,html=false,json=true"
 
+      - name: List mochawesome outputs (debug)
+        run: ls -lahR cypress/reports || true
+
       - name: Upload mochawesome JSON (${{ matrix.browser }})
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-ui-${{ matrix.browser }} # Filename for the report
           path: cypress/reports/**/*.json
+          if-no-files-found: error
 
   cypress-api:
     runs-on: ubuntu-latest
@@ -81,11 +85,15 @@ jobs:
               --reporter mochawesome \
               --reporter-options "reportDir=cypress/reports,overwrite=false,html=false,json=true"
 
+      - name: List mochawesome outputs (debug)
+        run: ls -lahR cypress/reports || true
+
       - name: Upload mochawesome JSON (api)
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-api
           path: cypress/reports/**/*.json
+          if-no-files-found: error
   
   # Build the HTML report to be displayed
   build-report:

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -122,6 +122,7 @@ jobs:
           if [ -z "$FILES" ]; then
           echo "No mochawesome JSON files found under mochawesome-raw/"
           exit 1
+          fi
           npx mochawesome-merge "mochawesome-raw/**/**/*.json" > /tmp/merged.json
 
       - name: Generate combined HTML report

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
-  pull_request:  # Runs on all PRs, no matter the branch
+  pull_request:  # Runs on all PRs
+
+# Needed to push to gh-pages
+permissions:
+  contents: write  
 
 jobs:
   cypress-ui:
@@ -20,25 +24,31 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20 # This version will be supported for a while
+          node-version: 20
 
       - name: Install dependencies
         run: npm install
 
       - name: Clean Reports Folder
-        run: rm -rf cypress/reports || true # Delete reports folder (removes old screenshots, logs etc)
+        run: rm -rf cypress/reports || true 
 
       - name: Run UI Tests in ${{ matrix.browser }}
-        env: 
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} # Get record key from Github secrets for Cypress Cloud runs
-        run: npx cypress run --browser ${{ matrix.browser }} --headless --spec "cypress/e2e/ui/*.cy.js" --record --group "UI Tests - ${{ matrix.browser }}"
+        # Get record key from Github secrets for Cypress Cloud runs - disabled for now
+        #env: 
+        #  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        run: npx cypress run \
+              --browser ${{ matrix.browser }} \
+              --headless --spec "cypress/e2e/ui/*.cy.js" \
+              --record \
+              --group "UI Tests - ${{ matrix.browser }}" \
+              --reporter mochawesome \
+              --reporter-options "reportDir=cypress/reports,overwrite=false,html=false,json=true"
 
-      - name: Upload UI report
+      - name: Upload mochawesome JSON (${{ matrix.browser }})
         uses: actions/upload-artifact@v4
         with:
-          name: mochawesome-ui-${{ matrix.browser }} # Generates a report for each browser
+          name: mochawesome-ui-${{ matrix.browser }} # Filename for the report
           path: cypress/reports/
-          retention-days: 7 # Keep files for 7 days instead of the default 90
 
   cypress-api:
     runs-on: ubuntu-latest
@@ -58,15 +68,84 @@ jobs:
         run: rm -rf cypress/reports || true
 
       - name: Run API Tests 
+        # Get API auth login from Github secrets
         env:
-          CYPRESS_BOOKING_USERNAME: ${{ secrets.CYPRESS_BOOKING_USERNAME }} # Get API auth login from Github secrets
+          CYPRESS_BOOKING_USERNAME: ${{ secrets.CYPRESS_BOOKING_USERNAME }} 
           CYPRESS_BOOKING_PASSWORD: ${{ secrets.CYPRESS_BOOKING_PASSWORD }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} 
-        run: npx cypress run --headless --spec "cypress/e2e/api/*.cy.js" --record --group "API Tests"
+        run: npx cypress run \
+              --headless \
+              --spec "cypress/e2e/api/*.cy.js" \
+              --record \
+              --group "API Tests" \
+              --reporter mochawesome \
+              --reporter-options "reportDir=cypress/reports,overwrite=false,html=false,json=true"
 
-      - name: Upload API report
+      - name: Upload mochawesome JSON (api)
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-api
           path: cypress/reports/
-          retention-days: 7
+  
+  # Build the HTML report to be displayed
+  build-report:
+    needs: [cypress-ui, cypress-api]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install report tools
+        run: npm ci
+
+      - name: Download all JSON artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: mochawesome-raw
+
+      # Merge ALL JSONs from UI (both browsers) and API into one
+      - name: Merge mochawesome JSON
+        run: |
+          npx mochawesome-merge "mochawesome-raw/**/**/*.json" > /tmp/merged.json
+
+      - name: Generate combined HTML report
+        run: |
+          mkdir -p public
+          npx marge /tmp/merged.json \
+            --reportDir public \
+            --reportFilename index.html \
+            --inline \
+            --reportTitle "Cypress UI + API (All Browsers)"
+
+      - name: Upload combined HTML report (artifact)
+        uses: actions/upload-artifact@v4
+        with:
+          name: mochawesome-report
+          path: public
+
+  # Publish to GitHub Pages ONLY on push to main
+  deploy:
+    needs: build-report
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mochawesome-report
+          path: public
+     
+      # The JamesIves public repo enables publishing reports to GitHub Pages
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4 
+        with:
+          branch: gh-pages
+          folder: public

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-ui-${{ matrix.browser }} # Filename for the report
-          path: cypress/reports/**/*.json
+          path: cypress/reports/
           if-no-files-found: error
 
   cypress-api:
@@ -88,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-api
-          path: cypress/reports/**/*.json
+          path: cypress/reports/
           if-no-files-found: error
   
   # Build the HTML report to be displayed

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-ui-${{ matrix.browser }} # Filename for the report
-          path: cypress/reports/
+          path: cypress/reports/**/*.json
           if-no-files-found: error
 
   cypress-api:
@@ -88,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-api
-          path: cypress/reports/
+          path: cypress/reports/**/*.json
           if-no-files-found: error
   
   # Build the HTML report to be displayed
@@ -110,19 +110,21 @@ jobs:
       - name: Download all JSON artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: mochawesome-* 
           path: mochawesome-raw
+          merge-multiple: true
 
       - name: List downloaded artifacts (debug)
         run: |
           echo "Artifacts tree:"
           ls -lahR mochawesome-raw || true
           echo "Any JSON?"
-          find mochawesome-raw -type f -name '*.json' -maxdepth 5 -print || true
+          find mochawesome-raw -maxdepth 5 -type f -name '*.json' -print || true
 
       # Merge ALL JSONs from UI (both browsers) and API into one
       - name: Merge mochawesome JSON
         run: |
-          FILES=$(find mochawesome-raw -type f -name '*.json' -maxdepth 5)
+          FILES=$(find mochawesome-raw -maxdepth 5 -type f -name '*.json')
           if [ -z "$FILES" ]; then
           echo "No mochawesome JSON files found under mochawesome-raw/"
           exit 1

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -40,9 +40,7 @@ jobs:
               --browser ${{ matrix.browser }} \
               --headless --spec "cypress/e2e/ui/*.cy.js" \
               --record \
-              --group "UI Tests - ${{ matrix.browser }}" \
-              --reporter mochawesome \
-              --reporter-options "reportDir=cypress/reports,overwrite=false,html=false,json=true"
+              --group "UI Tests - ${{ matrix.browser }}"             
 
       - name: List mochawesome outputs (debug)
         run: ls -lahR cypress/reports || true
@@ -81,9 +79,7 @@ jobs:
               --headless \
               --spec "cypress/e2e/api/*.cy.js" \
               --record \
-              --group "API Tests" \
-              --reporter mochawesome \
-              --reporter-options "reportDir=cypress/reports,overwrite=false,html=false,json=true"
+              --group "API Tests"
 
       - name: List mochawesome outputs (debug)
         run: ls -lahR cypress/reports || true

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -108,9 +108,20 @@ jobs:
         with:
           path: mochawesome-raw
 
+      - name: List downloaded artifacts (debug)
+        run: |
+          echo "Artifacts tree:"
+          ls -lahR mochawesome-raw || true
+          echo "Any JSON?"
+          find mochawesome-raw -type f -name '*.json' -maxdepth 5 -print || true
+
       # Merge ALL JSONs from UI (both browsers) and API into one
       - name: Merge mochawesome JSON
         run: |
+          FILES=$(find mochawesome-raw -type f -name '*.json' -maxdepth 5)
+          if [ -z "$FILES" ]; then
+          echo "No mochawesome JSON files found under mochawesome-raw/"
+          exit 1
           npx mochawesome-merge "mochawesome-raw/**/**/*.json" > /tmp/merged.json
 
       - name: Generate combined HTML report

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-ui-${{ matrix.browser }} # Filename for the report
-          path: cypress/reports/
+          path: cypress/reports/**/*.json
 
   cypress-api:
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mochawesome-api
-          path: cypress/reports/
+          path: cypress/reports/**/*.json
   
   # Build the HTML report to be displayed
   build-report:

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require('cypress');
 const webpack = require('@cypress/webpack-preprocessor');
 const webpackConfig = require('./webpack.config.js');
 
+const isCI = process.env.CI === 'true';
 module.exports = defineConfig({
   projectId: 'in78pu', // Project ID is used for Cypress Cloud
   e2e: {
@@ -17,8 +18,8 @@ module.exports = defineConfig({
     reporter: 'cypress-mochawesome-reporter',
     reporterOptions: {
       reportDir: 'cypress/reports',
-      overwrite: true, // Only displays one report per run locally
-      html: true,
+      overwrite: true, 
+      html: !isCI, // Only generate HTML when generating report locally
       json: true,
       charts: true, 
       embeddedScreenshots: true,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -18,7 +18,7 @@ module.exports = defineConfig({
     reporter: 'cypress-mochawesome-reporter',
     reporterOptions: {
       reportDir: 'cypress/reports',
-      overwrite: true, 
+      overwrite: false, 
       html: !isCI, // Only generate HTML when generating report locally
       json: true,
       charts: true, 


### PR DESCRIPTION
### Overview

Updates the CI workflow to automatically publish a merged Mochawesome HTML report to GitHub Pages whenever changes are merged to main. This makes the latest combined UI + API test results viewable in a browser without downloading artifacts.

### Changes

- Merge all JSON into a single HTML report via mochawesome-merge and marge.
- Upload the HTML as a workflow artifact for all runs.
- Deploy the HTML to GitHub Pages only on pushes to main.